### PR TITLE
TopLists: GPlay Invalid response checks

### DIFF
--- a/controllers/listController.js
+++ b/controllers/listController.js
@@ -56,7 +56,15 @@ const fetchList = async (collection, category, num, country) => {
       // Fetch top list based on the count or the maximum limit
       const toplist = await fetchList(collection, category, num, country);
       console.log(`Scraped Top ${toplist.length} Apps for ${collection} and ${category}`);
-      
+
+      if (!toplist || !Array.isArray(toplist) || toplist.length === 0) {
+        console.log("No results returned from fetchList");
+        return res.json({
+          totalCount: 0,
+          results: []
+        });
+      }
+    
       const cleanedTopListResults = toplist.map(
         (result) => {
           // Clean the summary column


### PR DESCRIPTION
Hey Johan/Jeshwin! Could we get this set up on the test site? I can't get this to fail locally, and I don't have a local nginx configuration, but in theory this should fix our toplists issues. I do need to run some experiments to see if our requests are causing the 500 error and remove some categories in that case.