### PR TITLE
Fix missing /api routes for toplists and reviews relog

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,11 +35,17 @@ app.post("/email", searchController.addEmailNotification);
 
 // Bulk reviews relog
 app.use("/download-reviews-relog", downloadReviewsRelog);
+app.use("/api/download-reviews-relog", downloadReviewsRelog);
 
 // Top lists
 app.use("/toplists", scrapeList);
 app.use("/download-top-relog", downloadTopChartsRelog);
 app.use("/download-top-csv", downloadTopChartsCSV);
+
+// Top lists (via /api prefix, as called by the frontend)
+app.use("/api/toplists", scrapeList);
+app.use("/api/download-top-relog", downloadTopChartsRelog);
+app.use("/api/download-top-csv", downloadTopChartsCSV);
 
 // Basic liveness check endpoint (for load balancers)
 app.get("/health", (req, res) => {


### PR DESCRIPTION
Fixes #51

The frontend calls these routes with the /api prefix, but they were only registered at the root level on the backend, causing the catch-all route to return HTML instead of data.

Added the missing /api prefixed routes for:
- /api/toplists
- /api/download-top-csv
- /api/download-top-relog
- /api/download-reviews-relog

Tested locally - Top Charts now returns results and the ZIP download works correctly.