### PR TITLE
86 implement redis cache gplay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ build
 .DS_Store
 # search_results.csv
 
+# Claude Code local files
+CLAUDE.md
+docs/
+previous_session.txt
+
 # Logs
 logs
 *.log

--- a/controllers/searchController.js
+++ b/controllers/searchController.js
@@ -9,6 +9,7 @@ const json_raw = require("../package.json");
 const nodeTTL = require("node-ttl");
 const nodemailer = require("nodemailer");
 var node_ttl = new nodeTTL();
+const redis = require("../utilities/cacheClient");
 
 const path = require("path");
 const file_name = path.basename(__filename);
@@ -56,6 +57,18 @@ const searchController = async (req, res) => {
     console.error("Missing search query");
     return res.status(400).json({ error: "Search query is missing.\n" });
   }
+
+  const cacheKey = `gplay:c:${country}_t:${query}_p:${permissions}`;
+  try {
+    const cached = await redis.get(cacheKey);
+    if (cached) {
+      console.log(`[Cache] Redis hit for "${query}"`);
+      return res.json(JSON.parse(cached));
+    }
+  } catch (e) {
+    console.warn('[Cache] Redis unavailable, falling back to scraper:', e.message);
+  }
+
   try {
     const mainResults = await search({ term: query, country: country });
     const relatedResults = [];
@@ -388,10 +401,16 @@ const searchController = async (req, res) => {
 
     node_ttl.push(pushQuery, csvData, null, 604800); // 1 week
     console.log("CSV stored on backend");
-    return res.json({
-      totalCount: uniqueResults.length,
-      results: resultsToSend,
-    });
+
+    const responsePayload = { totalCount: uniqueResults.length, results: resultsToSend };
+    try {
+      await redis.set(cacheKey, JSON.stringify(responsePayload), 'EX', 604800);
+      console.log(`[Cache] Stored in Redis: "${query}"`);
+    } catch (e) {
+      console.warn('[Cache] Redis write failed:', e.message);
+    }
+
+    return res.json(responsePayload);
   } catch (error) {
     console.error("Error occurred during search:", error);
     return res

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const { downloadRelog, downloadCSV, addEmailNotification } = require("./controll
 const { scrapeReviews, downloadReviewsRelog } = require("./controllers/reviewsController");
 const { downloadTopChartsCSV, downloadTopChartsRelog, scrapeList } = require("./controllers/listController");
 const { startPeriodicHealthCheck, getHealthStatus, checkAllServices } = require("./utilities/healthCheck");
+const { prewarmCache } = require("./utilities/prewarmCache");
 
 const path = require("path");
 const searchController = require("./controllers/searchController");
@@ -74,4 +75,7 @@ app.listen(port, () => {
 
     // Start periodic health check for scraper services
     startPeriodicHealthCheck();
+
+    // Pre-warm Redis cache for example searches (fire-and-forget, 2s delay for routes to settle)
+    setTimeout(() => prewarmCache().catch((err) => console.error('[Cache] Pre-warm error:', err.message)), 2000);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,19 @@
                 "express-useragent": "^1.0.15",
                 "google-play-scraper": "^9.2.0",
                 "googleapis": "^152.0.0",
+                "ioredis": "^5.10.1",
                 "log-timestamp": "^0.3.0",
                 "morgan": "^1.10.0",
                 "natural": "^6.10.4",
                 "node-ttl": "^0.2.0",
                 "nodemailer": "^8.0.1"
             }
+        },
+        "node_modules/@ioredis/commands": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+            "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+            "license": "MIT"
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
@@ -704,6 +711,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/depd": {
@@ -1569,6 +1585,53 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
         },
+        "node_modules/ioredis": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+            "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@ioredis/commands": "1.5.1",
+                "cluster-key-slot": "^1.1.0",
+                "debug": "^4.3.4",
+                "denque": "^2.1.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.isarguments": "^3.1.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0",
+                "standard-as-callback": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ioredis"
+            }
+        },
+        "node_modules/ioredis/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ioredis/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1681,6 +1744,18 @@
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
+        },
+        "node_modules/lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+            "license": "MIT"
         },
         "node_modules/log-prefix": {
             "version": "0.1.1",
@@ -2674,6 +2749,27 @@
                 "@redis/time-series": "1.1.0"
             }
         },
+        "node_modules/redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "license": "MIT",
+            "dependencies": {
+                "redis-errors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/resolve-alpn": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
@@ -2921,6 +3017,12 @@
             "engines": {
                 "node": ">= 10.x"
             }
+        },
+        "node_modules/standard-as-callback": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+            "license": "MIT"
         },
         "node_modules/statuses": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "express-useragent": "^1.0.15",
         "google-play-scraper": "^9.2.0",
         "googleapis": "^152.0.0",
+        "ioredis": "^5.10.1",
         "log-timestamp": "^0.3.0",
         "morgan": "^1.10.0",
         "natural": "^6.10.4",

--- a/utilities/cacheClient.js
+++ b/utilities/cacheClient.js
@@ -1,0 +1,13 @@
+const Redis = require('ioredis');
+
+const redis = new Redis({
+  host: process.env.REDIS_HOST || '127.0.0.1',
+  port: parseInt(process.env.REDIS_PORT) || 6379,
+  password: process.env.REDIS_PASSWORD || undefined,
+  enableOfflineQueue: false,
+});
+
+redis.on('connect', () => console.log('[Redis] connected'));
+redis.on('error', (err) => console.error('[Redis] connection error:', err.message));
+
+module.exports = redis;

--- a/utilities/prewarmCache.js
+++ b/utilities/prewarmCache.js
@@ -1,0 +1,41 @@
+const axios = require('axios');
+const redis = require('./cacheClient');
+
+const DEFAULT_SEARCHES = 'medication reminders,self-care,smartphone addiction';
+const EXAMPLE_SEARCHES = (process.env.CACHE_PREWARM_QUERIES || DEFAULT_SEARCHES)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const BASE_URL = `http://localhost:${process.env.PORT || 5001}`;
+
+async function prewarmCache() {
+  if (process.env.CACHE_PREWARM === 'false') return;
+  console.log('[Cache] Starting pre-warm for example searches...');
+  await Promise.allSettled(
+    EXAMPLE_SEARCHES.map(async (query) => {
+      const cacheKey = `gplay:c:US_t:${query}_p:false`;
+      try {
+        const exists = await redis.exists(cacheKey);
+        if (exists) {
+          console.log(`[Cache] Pre-warm skipped (already cached): "${query}"`);
+          return;
+        }
+      } catch (e) {
+        console.warn(`[Cache] Redis check failed for "${query}", proceeding with scrape:`, e.message);
+      }
+      try {
+        await axios.get(`${BASE_URL}/search`, {
+          params: { query, countryCode: 'US', includePermissions: false },
+          timeout: 10 * 60 * 1000,
+        });
+        console.log(`[Cache] Pre-warmed: "${query}"`);
+      } catch (err) {
+        console.error(`[Cache] Pre-warm failed for "${query}":`, err.message);
+      }
+    })
+  );
+  console.log('[Cache] Pre-warm complete.');
+}
+
+module.exports = { prewarmCache };


### PR DESCRIPTION
Description:
  ## Summary
  - Adds `ioredis` as a Redis client (`utilities/cacheClient.js`) with graceful fallback — if Redis is unreachable, scraper runs normally
  - Caches search results in Redis keyed by `gplay:c:{country}_t:{query}_p:{permissions}` with 1-week TTL
  - Pre-warms cache on server startup for the 3 default example searches, skipping any queries already cached in Redis
  
  ## Test plan
  - [ ] Start server with Redis running — confirm `[Redis] connected` log on startup
  - [ ] Run one of the 3 example searches, confirm `[Cache] Stored in Redis` log
  - [ ] Run the same search again, confirm `[Cache] Redis hit` and response is immediate
  - [ ] Start server with Redis down — confirm server starts normally and searches still work
  - [ ] Set `CACHE_PREWARM=false` in `.env` and restart — confirm no pre-warm fires
