### PR TITLE
86 implement redis cache ios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ build
 .nyc
 .DS_Store
 search_results.csv
+
+# Claude Code local files
+CLAUDE.md
+docs/
+previous_session.txt
 package-lock.json
 
 # Logs

--- a/controllers/searchController.js
+++ b/controllers/searchController.js
@@ -4,6 +4,7 @@ const { cleanText, jsonToCsv } = require("../utilities/jsonToCsv");
 const json_raw = require("../package.json");
 const nodeTTL = require("node-ttl");
 var node_ttl = new nodeTTL();
+const redis = require("../utilities/cacheClient");
 
 const path = require("path");
 const file_name = path.basename(__filename);
@@ -49,6 +50,18 @@ const searchController = async (req, res) => {
     console.error("Missing search query");
     return res.status(400).json({ error: "Search query is missing.\n" });
   }
+
+  const cacheKey = `ios:c:${country}_t:${query}`;
+  try {
+    const cached = await redis.get(cacheKey);
+    if (cached) {
+      console.log(`[Cache] Redis hit for "${query}"`);
+      return res.json(JSON.parse(cached));
+    }
+  } catch (e) {
+    console.warn('[Cache] Redis unavailable, falling back to scraper:', e.message);
+  }
+
   try {
     // if an appID is passed as the query
     const mainResults = await search({ term: query, country: country });
@@ -195,10 +208,16 @@ const searchController = async (req, res) => {
     // we want users to get the CSV results corresponding to their entire search, so an update was necessary
     node_ttl.push(pushQuery, csvData, null, 604800); // 1 week
     console.log("CSV stored on backend");
-    return res.json({
-      totalCount: uniqueResults.length,
-      results: resultsToSend,
-    });
+
+    const responsePayload = { totalCount: uniqueResults.length, results: resultsToSend };
+    try {
+      await redis.set(cacheKey, JSON.stringify(responsePayload), 'EX', 604800);
+      console.log(`[Cache] Stored in Redis: "${query}"`);
+    } catch (e) {
+      console.warn('[Cache] Redis write failed:', e.message);
+    }
+
+    return res.json(responsePayload);
   } catch (error) {
     console.error("Error occurred during search:", error);
     return res

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const { downloadRelog, downloadCSV } = require('./controllers/searchController')
 const { scrapeReviews, downloadReviewsRelog } = require('./controllers/reviewsController'); 
 const { scrapeList, downloadTopChartsCSV, downloadTopChartsRelog} = require('./controllers/listController');
 const { startPeriodicHealthCheck, getHealthStatus, checkAllServices } = require('./utilities/healthCheck');
+const { prewarmCache } = require('./utilities/prewarmCache');
 const path = require('path');
 const app = express();
 const port = 5002;
@@ -50,7 +51,10 @@ app.get('/health/scraper', async (req, res) => {
 
 app.listen(port, () => {
   console.log(`Server is running on http://localhost:${port}`);
-  
+
   // Start periodic health check for scraper services
   startPeriodicHealthCheck();
+
+  // Pre-warm Redis cache for example searches (fire-and-forget, 2s delay for routes to settle)
+  setTimeout(() => prewarmCache().catch((err) => console.error('[Cache] Pre-warm error:', err.message)), 2000);
 });

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "express-useragent": "^1.0.15",
+    "ioredis": "^5.10.1",
     "log-timestamp": "^0.3.0",
     "morgan": "^1.10.0",
     "natural": "^6.10.4",
-    "nodemailer": "^8.0.1",
-    "node-ttl": "^0.2.0"
+    "node-ttl": "^0.2.0",
+    "nodemailer": "^8.0.1"
   },
   "directories": {
     "test": "test"

--- a/utilities/cacheClient.js
+++ b/utilities/cacheClient.js
@@ -1,0 +1,13 @@
+const Redis = require('ioredis');
+
+const redis = new Redis({
+  host: process.env.REDIS_HOST || '127.0.0.1',
+  port: parseInt(process.env.REDIS_PORT) || 6379,
+  password: process.env.REDIS_PASSWORD || undefined,
+  enableOfflineQueue: false,
+});
+
+redis.on('connect', () => console.log('[Redis] connected'));
+redis.on('error', (err) => console.error('[Redis] connection error:', err.message));
+
+module.exports = redis;

--- a/utilities/prewarmCache.js
+++ b/utilities/prewarmCache.js
@@ -1,0 +1,41 @@
+const axios = require('axios');
+const redis = require('./cacheClient');
+
+const DEFAULT_SEARCHES = 'medication reminders,self-care,smartphone addiction';
+const EXAMPLE_SEARCHES = (process.env.CACHE_PREWARM_QUERIES || DEFAULT_SEARCHES)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const BASE_URL = `http://localhost:${process.env.PORT || 5002}`;
+
+async function prewarmCache() {
+  if (process.env.CACHE_PREWARM === 'false') return;
+  console.log('[Cache] Starting pre-warm for example searches...');
+  await Promise.allSettled(
+    EXAMPLE_SEARCHES.map(async (query) => {
+      const cacheKey = `ios:c:US_t:${query}`;
+      try {
+        const exists = await redis.exists(cacheKey);
+        if (exists) {
+          console.log(`[Cache] Pre-warm skipped (already cached): "${query}"`);
+          return;
+        }
+      } catch (e) {
+        console.warn(`[Cache] Redis check failed for "${query}", proceeding with scrape:`, e.message);
+      }
+      try {
+        await axios.get(`${BASE_URL}/search`, {
+          params: { query, countryCode: 'US' },
+          timeout: 10 * 60 * 1000,
+        });
+        console.log(`[Cache] Pre-warmed: "${query}"`);
+      } catch (err) {
+        console.error(`[Cache] Pre-warm failed for "${query}":`, err.message);
+      }
+    })
+  );
+  console.log('[Cache] Pre-warm complete.');
+}
+
+module.exports = { prewarmCache };


### PR DESCRIPTION
Description:
  ## Summary
  - Adds `ioredis` as a Redis client (`utilities/cacheClient.js`) with graceful fallback — if Redis is unreachable, scraper runs normally
  - Caches search results in Redis keyed by `ios:c:{country}_t:{query}` with 1-week TTL
  - Pre-warms cache on server startup for the 3 default example searches, skipping any queries already cached in Redis
  
  ## Test plan
  - [ ] Start server with Redis running — confirm `[Redis] connected` log on startup
  - [ ] Run one of the 3 example searches, confirm `[Cache] Stored in Redis` log
  - [ ] Run the same search again, confirm `[Cache] Redis hit` and response is immediate
  - [ ] Start server with Redis down — confirm server starts normally and searches still work
  - [ ] Set `CACHE_PREWARM=false` in `.env` and restart — confirm no pre-warm fires